### PR TITLE
Added to the code p() as alias for fmt.Println() and pp() as alias for pp.Print()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # gommand
 Go one liner program, similar to python -c
 
-Usage: gommand 'fmt.Println("Hello, Gommand!")' <br />
-       gommand 'h := md5.New(); io.WriteString(h, "Md5 me"); fmt.Printf("%x", h.Sum(nil))'
+Added to the code p() as alias for fmt.Println()
+
+Usage:
+
+    gommand 'fmt.Println("Hello, Gommand!")'
+    gommand 'h := md5.New(); io.WriteString(h, "Md5 me"); fmt.Printf("%x", h.Sum(nil))'
+    gommand 'p("Array:", []int{1, 2, 3})'

--- a/README.md
+++ b/README.md
@@ -7,4 +7,5 @@ Go one liner program, similar to python -c
        <li>gommand 'h := md5.New(); io.WriteString(h, "Md5 me"); fmt.Printf("%x", h.Sum(nil))'</li>
        <li>gommand 'p("Array:", []int{1, 2, 3})'</li>
        <li>gommand 'pp(os.Environ())' # dump os env, need install "github.com/k0kubun/pp"</li>
+       <li>gommand 'p(os.Args[1:])' 1 2 3</li>
 </ul>

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 Go one liner program, similar to python -c
 
 Added to the code p() as alias for fmt.Println()
+If "github.com/k0kubun/pp" is installed - add pp() as alias for pp.Print()
 
 Usage:
 
     gommand 'fmt.Println("Hello, Gommand!")'
     gommand 'h := md5.New(); io.WriteString(h, "Md5 me"); fmt.Printf("%x", h.Sum(nil))'
     gommand 'p("Array:", []int{1, 2, 3})'
+    gommand 'pp(os.Environ())' # get os env, need install "github.com/k0kubun/pp"

--- a/gommand.go
+++ b/gommand.go
@@ -11,6 +11,22 @@ import(
 	"golang.org/x/tools/imports"
 )
 
+const code_tmpl = `
+package main
+
+import(
+	"fmt"
+)
+
+func p(args ...interface{}) {
+	fmt.Println(args...)
+}
+
+func main() {
+	%v
+}
+`
+
 func run(name string) (string, error) {
 	out, err := exec.Command("go", "run", name).CombinedOutput()
 	if err != nil {
@@ -73,7 +89,7 @@ func main() {
 	}()
 
 	code := os.Args[1]
-	bp := fmt.Sprintf("package main\nfunc main() {\n\t%v\n}", code)
+	bp := fmt.Sprintf(code_tmpl, code)
 
 	if err = ioutil.WriteFile(file.Name(), []byte(bp), 0644); err != nil {
 		log.Printf("main: error writing code to temp file: %v\n", err)

--- a/gommand.go
+++ b/gommand.go
@@ -107,7 +107,7 @@ func main() {
 		import (pp_dumper "github.com/k0kubun/pp")
 
 		func pp(args ...interface{}) {
-			pp_dumper.Print(args...)
+			pp_dumper.Println(args...)
 		}
 		`
 	}

--- a/gommand.go
+++ b/gommand.go
@@ -28,8 +28,10 @@ func main() {
 }
 `
 
-func run(name string) (string, error) {
-	out, err := exec.Command("go", "run", name).CombinedOutput()
+func run(name string, args []string) (string, error) {
+	go_args := []string{"run", name}
+	go_args = append(go_args, args...)
+	out, err := exec.Command("go", go_args...).CombinedOutput()
 	if err != nil {
 		return "", err
 	}
@@ -112,7 +114,7 @@ func main() {
 		log.Printf("main: error editing imports: %v\n", err)
 	}
 
-	out, err := run(file.Name())
+	out, err := run(file.Name(), os.Args[2:])
 	if err != nil {
 		fmt.Println("There was an error in your go code.")
 	}


### PR DESCRIPTION
Added:
- p() as alias for fmt.Println()
- pp() as alias for pp.Print(), `github.com/k0kubun/pp` must be installed for use pp() and otherwise not required
- allow use command arguments for oneliner
