### PR TITLE
Bug fix. Tempfile isn't removed when args is empty.

### DIFF
--- a/gommand.go
+++ b/gommand.go
@@ -64,6 +64,10 @@ func main() {
 	if len(os.Args) < 2 {
 		usage()
 	}
+	code := os.Args[1]
+	if code == "" {
+		usage()
+	}
 
 	file, err := tempFile()
 	if err != nil {
@@ -76,11 +80,6 @@ func main() {
 			log.Printf("main: error removing temp file: %v\n", err)
 		}
 	}()
-
-	code := os.Args[1]
-	if code == "" {
-		usage()
-	}
 
 	// bp holds the go boiler plate code with user inputted code added.
 	bp := fmt.Sprintf("package main\nfunc main() {\n\t%v\n}", code)


### PR DESCRIPTION
Thanks great tool!
# Problem

Tempfile isn't removed when go code is empty.

e.g.

![gommand](https://cloud.githubusercontent.com/assets/4361134/15102704/7b6dc422-15dd-11e6-9d46-331671dc79f7.png)
