### PR TITLE
Update Go version 1.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Go one liner program similar to python -c
 ## How can I get it?
 
 ```
-go get github.com/sno6/gommand
+go install github.com/sno6/gommand@latest
 ```
 
 ## Examples 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,10 @@
 module github.com/sno6/gommand
 
-go 1.12
+go 1.19
 
-require golang.org/x/tools v0.0.0-20190501045030-23463209683d
+require golang.org/x/tools v0.5.0
+
+require (
+	golang.org/x/mod v0.7.0 // indirect
+	golang.org/x/sys v0.4.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,6 @@
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/tools v0.0.0-20190501045030-23463209683d h1:D7DVZUZEUgsSIDTivnUtVeGfN5AvhDIKtdIZAqx0ieE=
-golang.org/x/tools v0.0.0-20190501045030-23463209683d/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/mod v0.7.0 h1:LapD9S96VoQRhi/GrNTqeBJFrUjs5UHCAtTlgwA5oZA=
+golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
+golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/tools v0.5.0 h1:+bSpV5HIeWkuvgaMfI3UmKRThoTA5ODJTUd8T17NO+4=
+golang.org/x/tools v0.5.0/go.mod h1:N+Kgy78s5I24c24dU8OfWNEotWjutIs8SnJvn5IDq+k=


### PR DESCRIPTION
Hi👋! Thanks for making gommand.
It's nice to be able to run Go code easily!

I've upped Go version on this PR.
What this PR solves is that we can try new Go implementations that we could not run before.
For example, [strings.Clone](https://pkg.go.dev/strings#pkg-functions) was added in 1.18 and will be executable in this PR.

```console
$ gommand 'fmt.Println(strings.Clone("Hello!"))'
Hello!
```